### PR TITLE
Listen address is customizable via HTTP_ADDR env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.0 AS builder
+FROM golang:1.13.6 AS builder
 COPY http.go .
 RUN go get -v -d .
 RUN go build http.go
@@ -6,5 +6,7 @@ RUN go build http.go
 FROM ubuntu:16.04
 
 COPY --from=builder /go/http /usr/local/bin/http
+
+ENV HTTP_ADDR=:8080
 
 ENTRYPOINT ["/usr/local/bin/http"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Now, when a request is made to `http://back:8080/`, it will behave as if the URI
 
 The requests return plain text data (content-type: text/plain) with a short summary of every executed operation. If an error was encountered, the HTTP status will be 400 and the payload data will include a line prefixed with 'err: ...'.
 
+By default, the server listens on all network interfaces on port 8080. This can be customized via `HTTP_ADDR` environment variable, e.g.:
+
+```
+docker run -d -p 8080:8081 -e HTTP_ADDR=:8081 --name front co-http
+```
+
 ## Deploying 3-tier component stack with Kubernetes
 
 See `k8s` sub-directory for sample app deployment with Optune servo for Kubernetes and using Apache Benchmark.

--- a/http.go
+++ b/http.go
@@ -103,6 +103,9 @@ func main() {
 	var s http.Server
 	var err error
 	s.Addr = ":8080"
+	if addr := os.Getenv("HTTP_ADDR"); addr != "" {
+		s.Addr = addr
+	}
 
 	// default query from command line
 	if len(os.Args) > 1 {


### PR DESCRIPTION
+ Bumped golang version in builder image to 1.13.6 to make `go get` stop complaining.